### PR TITLE
[fix:#10][pkg:bufioutil]: pool is unnecessary for bufioReader

### DIFF
--- a/pkg/bufioutil/bufio_reader_test.go
+++ b/pkg/bufioutil/bufio_reader_test.go
@@ -1,50 +1,60 @@
 package bufioutil
 
 import (
+	"bufio"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-const (
-	_testReadFile = "bufioReader.test"
-)
-
-var (
-	_readContent = []byte("eleme.ci.etrace")
-)
-
 func Test_NewBufioReader(t *testing.T) {
-	defer os.Remove(_testReadFile)
-	br, err := NewBufioReader(_testReadFile)
+	defer os.Remove(_testFile)
+	br, err := NewBufioReader(_testFile)
+	assert.NotNil(t, err)
+	assert.Nil(t, br)
+
+	os.Create(_testFile)
+	br, err = NewBufioReader(_testFile)
 	assert.Nil(t, err)
 	assert.NotNil(t, br)
 }
 
-func TestBufioWriter_setContent(t *testing.T) {
-	br := bufioReader{}
+func TestBufioReader_content(t *testing.T) {
+	defer os.Remove(_testFile)
+	bw, _ := NewBufioWriter(_testFile)
 
-	br.setContent([]byte("a"))
+	f, _ := os.Open(_testFile)
+	br := bufioReader{
+		f: f,
+		r: bufio.NewReader(f)}
+
+	bw.Write([]byte("a"))
+	bw.Flush()
+	br.Read()
 	assert.Equal(t, 1, len(br.content))
 	assert.Equal(t, 1, cap(br.content))
 
-	br.setContent([]byte("abcde"))
+	bw.Write([]byte("abcde"))
+	bw.Flush()
+	br.Read()
 	assert.Equal(t, 5, len(br.content))
 	assert.Equal(t, 5, cap(br.content))
 
-	br.setContent([]byte("xy"))
+	bw.Write([]byte("xy"))
+	bw.Flush()
+	br.Read()
 	assert.Equal(t, 2, len(br.content))
 	assert.Equal(t, 5, cap(br.content))
 }
 
 func BenchmarkBufioReader_Read(b *testing.B) {
-	defer os.Remove(_testReadFile)
-	bw, _ := NewBufioWriter(_testReadFile)
-	br, _ := NewBufioReader(_testReadFile)
+	defer os.Remove(_testFile)
+	bw, _ := NewBufioWriter(_testFile)
+	br, _ := NewBufioReader(_testFile)
 
 	for i := 0; i < b.N; i++ {
-		bw.Write(_readContent)
+		bw.Write(_testContent)
 	}
 	bw.Sync()
 	b.ResetTimer()
@@ -53,7 +63,7 @@ func BenchmarkBufioReader_Read(b *testing.B) {
 		eof, content, err := br.Read()
 		if i < 100 || i > b.N-100 {
 			assert.False(b, eof)
-			assert.Equal(b, _readContent, content)
+			assert.Equal(b, _testContent, content)
 			assert.Nil(b, err)
 		}
 	}
@@ -64,13 +74,14 @@ func BenchmarkBufioReader_Read(b *testing.B) {
 }
 
 func TestBufioReader_Count_Reset_Close(t *testing.T) {
-	defer os.Remove(_testReadFile)
-	defer os.Remove("new" + _testReadFile)
-	bw, _ := NewBufioWriter(_testReadFile)
-	br, _ := NewBufioReader(_testReadFile)
+	defer os.Remove(_testFile)
+	defer os.Remove("new" + _testFile)
+	os.Create("new" + _testFile)
+	bw, _ := NewBufioWriter(_testFile)
+	br, _ := NewBufioReader(_testFile)
 
 	for i := 0; i < 100000; i++ {
-		bw.Write(_readContent)
+		bw.Write(_testContent)
 	}
 	bw.Sync()
 
@@ -80,11 +91,25 @@ func TestBufioReader_Count_Reset_Close(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, int(br.Count()), (len(_readContent)+4)*100000)
+	assert.Equal(t, int(br.Count()), (len(_testContent)+4)*100000)
 
-	err := br.Reset("new" + _testReadFile)
+	err := br.Reset("new" + _testFile)
 	assert.Nil(t, err)
 	assert.Equal(t, 0, int(br.Count()))
 
 	assert.Nil(t, br.Close())
+}
+
+func TestBufioReader_Size(t *testing.T) {
+	defer os.Remove(_testFile)
+	bw, _ := NewBufioWriter(_testFile)
+	br, _ := NewBufioReader(_testFile)
+
+	for i := 1; i < 11; i++ {
+		bw.Write(_testContent)
+		bw.Flush()
+		size, err := br.Size()
+		assert.Nil(t, err)
+		assert.Equal(t, int64(len(_testContent)*i+4*i), size)
+	}
 }

--- a/pkg/bufioutil/bufio_writer_test.go
+++ b/pkg/bufioutil/bufio_writer_test.go
@@ -9,56 +9,74 @@ import (
 )
 
 const (
-	_testWriteFile = "bufioWriter.test"
+	_testFile = "bufioio.test"
 )
 
 var (
-	_writeContent = []byte("TEST LINDB WRITE")
+	_testContent = []byte("eleme.ci.etrace")
 )
 
 func TestNewBufioWriter(t *testing.T) {
-	defer os.Remove(_testWriteFile)
-	bw, err := NewBufioWriter(_testWriteFile)
+	defer os.Remove(_testFile)
+	bw, err := NewBufioWriter(_testFile)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, bw)
 }
 
+func TestBufioWriter_Reset(t *testing.T) {
+	defer os.Remove(_testFile)
+	defer os.Remove("new" + _testFile)
+
+	bw, _ := NewBufioWriter(_testFile)
+	bw.Write([]byte("test"))
+	bw.Flush()
+	assert.Equal(t, int64(8), bw.Size())
+
+	err := bw.Reset("new" + _testFile)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), bw.Size())
+	bw.Write([]byte("abcd"))
+
+	stat, _ := os.Stat(_testFile)
+	assert.Equal(t, int64(8), stat.Size())
+}
+
 func TestBufioWriter_Write_Size(t *testing.T) {
-	defer os.Remove(_testWriteFile)
-	bw, _ := NewBufioWriter(_testWriteFile)
+	defer os.Remove(_testFile)
+	bw, _ := NewBufioWriter(_testFile)
 
 	for i := 0; i < 30; i++ {
-		bw.Write(_writeContent)
+		bw.Write(_testContent)
 	}
-	assert.Equal(t, len(_writeContent)*30+120, int(bw.Size()))
+	assert.Equal(t, len(_testContent)*30+120, int(bw.Size()))
 }
 
 func BenchmarkBufioWriter_Write(b *testing.B) {
-	defer os.Remove(_testWriteFile)
-	bw, _ := NewBufioWriter(_testWriteFile)
+	defer os.Remove(_testFile)
+	bw, _ := NewBufioWriter(_testFile)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := bw.Write(_writeContent); err != nil {
+		if _, err := bw.Write(_testContent); err != nil {
 			assert.Nil(b, err)
 		}
 	}
 }
 
 func TestBufioWriter_Close(t *testing.T) {
-	defer os.Remove(_testWriteFile)
-	bw, _ := NewBufioWriter(_testWriteFile)
+	defer os.Remove(_testFile)
+	bw, _ := NewBufioWriter(_testFile)
 
-	expectedLength := (len(_writeContent) + 4) * 100000
+	expectedLength := (len(_testContent) + 4) * 100000
 	for i := 0; i < 100000; i++ {
-		bw.Write(_writeContent)
+		bw.Write(_testContent)
 	}
 	bw.Sync()
 	assert.Nil(t, bw.Sync())
 	assert.Nil(t, bw.Close())
 
-	data, err := ioutil.ReadFile(_testWriteFile)
+	data, err := ioutil.ReadFile(_testFile)
 	assert.Nil(t, err)
 	assert.Len(t, data, expectedLength)
 }

--- a/pkg/bufioutil/pool_test.go
+++ b/pkg/bufioutil/pool_test.go
@@ -1,0 +1,26 @@
+package bufioutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBuffer_PutBuffer(t *testing.T) {
+	buf3 := make([]byte, 3)
+
+	PutBuffer(&buf3)
+
+	gotBuf3 := GetBuffer(3)
+	assert.NotNil(t, gotBuf3)
+	assert.Len(t, *gotBuf3, 3)
+
+	assert.Len(t, *GetBuffer(1), 1)
+
+	gotBuf5 := GetBuffer(5)
+	assert.Len(t, *gotBuf5, 5)
+
+	gotBuf4 := GetBuffer(4)
+	assert.Len(t, *gotBuf4, 4)
+	assert.Equal(t, 4, cap(*gotBuf4))
+}


### PR DESCRIPTION
- remove truncate(), open read_only
- add size() to get the size of the underlying file
- pool is unnecessary, but still exported