### PR TITLE
[fix:#22][tsdb:memdb]: replace key from hash-number to string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,10 @@ GOLANGCI_LINT_VERSION ?= "latest"
 
 pre-test: ## go generate mock file.
 	if [ ! -e ${GOPATH}/bin/mockgen ]; then \
-		go get github.com/golang/mock/mockgen; \
+		go install github.com/golang/mock/mockgen; \
 	fi
+	go generate github.com/eleme/lindb/kv
+	go generate github.com/eleme/lindb/tsdb/metrictbl
 	go list ./... | grep -v '/vendor/' | xargs go generate
 
 	if [ ! -e ./bin/golangci-lint ]; then \

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
-	github.com/golang/mock v1.1.1
+	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.1
 	github.com/golang/snappy v0.0.1
 	github.com/google/btree v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/mock v1.1.1 h1:G5FRp8JnTd7RQH5kemVNlMeyXQAztQ3mOWV95KxsXH8=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
+github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -226,6 +228,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -253,6 +256,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
+golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=

--- a/kv/flusher.go
+++ b/kv/flusher.go
@@ -7,6 +7,8 @@ import (
 	"github.com/eleme/lindb/kv/version"
 )
 
+//go:generate mockgen -source ./flusher.go -destination=./flusher_mock.go -package kv
+
 // Flusher flushes data into kv store, for big data will be split into many sstable
 type Flusher interface {
 	// Add puts k/v pair

--- a/pkg/encoding/tsd.go
+++ b/pkg/encoding/tsd.go
@@ -163,13 +163,3 @@ func (d *TSDDecoder) Value() uint64 {
 	}
 	return 0
 }
-
-// DecodeTSDTime decodes start-time-slot and end-time-slot of tsd.
-// a simple method extracted from NewTSDDecoder to reduce gc pressure.
-func DecodeTSDTime(data []byte) (startTime, endTime int) {
-	binary := stream.BinaryReader(data)
-	startTime = int(binary.ReadInt32())
-	count := int(binary.ReadInt32())
-	endTime = startTime + count - 1
-	return
-}

--- a/tsdb/index/index.go
+++ b/tsdb/index/index.go
@@ -8,8 +8,8 @@ import "github.com/eleme/lindb/pkg/field"
 type IDGenerator interface {
 	// GenMetricID generates ID(uint32) from metricName
 	GenMetricID(metricName string) uint32
-	// GenTSID generates ID(uint32) from metricID and sortedTags
-	GenTSID(metricID uint32, sortedTags string) uint32
+	// GenTSID generates ID(uint32) from metricID, sortedTags and version.
+	GenTSID(metricID uint32, sortedTags string, version int64) uint32
 	// GenFieldID generates ID(uint32) from metricID and fieldName
 	GenFieldID(metricID uint32, fieldName string, fieldType field.Type) uint32
 }

--- a/tsdb/memdb/block_store.go
+++ b/tsdb/memdb/block_store.go
@@ -82,7 +82,7 @@ type block interface {
 	// getEndTime returns end time slot
 	getEndTime() int
 	// compact compress block data with agg func for rollup operation
-	compact(aggFunc field.AggFunc) error
+	compact(aggFunc field.AggFunc) (startSlot, endSlot int, err error)
 	// reset cleans block data, just reset container mark
 	reset()
 	// bytes returns compress data for block data
@@ -156,19 +156,20 @@ func (b *intBlock) updateValue(pos int, value int64) {
 }
 
 // compact compress block data
-func (b *intBlock) compact(aggFunc field.AggFunc) error {
+func (b *intBlock) compact(aggFunc field.AggFunc) (startSlot, endSlot int, err error) {
 	//TODO handle error
 	merger := newMerger(b, b.values, b.compress, aggFunc)
 	// do merge logic
 	merger.merge()
 
-	buf, err := merger.tsd.Bytes()
+	var buf []byte
+	buf, err = merger.tsd.Bytes()
 	if err != nil {
-		return err
+		return
 	}
 
 	b.compress = buf
-	return nil
+	return merger.startTime, merger.endTime, nil
 }
 
 // bytes returns compress data for block data
@@ -200,9 +201,9 @@ func (b *floatBlock) updateValue(pos int, value float64) {
 }
 
 // compact compress block data
-func (b *floatBlock) compact(aggFunc field.AggFunc) error {
+func (b *floatBlock) compact(aggFunc field.AggFunc) (startSlot, endSlot int, err error) {
 	//TODO need implement
-	return nil
+	return
 }
 
 // merger is merge operation which provides compress block data.

--- a/tsdb/memdb/database_test.go
+++ b/tsdb/memdb/database_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/eleme/lindb/models"
 	"github.com/eleme/lindb/pkg/field"
-	"github.com/eleme/lindb/pkg/hashers"
 	"github.com/eleme/lindb/pkg/interval"
 	"github.com/eleme/lindb/pkg/timeutil"
 
@@ -30,7 +29,7 @@ func Test_getBucket(t *testing.T) {
 	md, _ := newMemoryDatabase(ctx, 32, 10*1000, interval.Day)
 
 	for i := 0; i < 1000; i++ {
-		assert.NotNil(t, md.getBucket(hashers.Fnv32a(strconv.Itoa(i))))
+		assert.NotNil(t, md.getBucket(strconv.Itoa(i)))
 	}
 }
 
@@ -149,13 +148,13 @@ func Test_flushFamilyTo(t *testing.T) {
 	md.generator = gen
 
 	getMStore := func() *metricStore {
-		mStore := newMetricStore("cpu")
+		mStore := newMetricStore()
 		mStore.mutable = newVersionedTSMap()
 		mStore.immutable = append(mStore.immutable, newVersionedTSMap())
 		return mStore
 	}
-	md.mStoresList[0].m[hashers.Fnv32a("cpu")] = getMStore()
-	assert.Nil(t, md.flushFamilyTo(1, tw))
+	md.mStoresList[0].m["cpu"] = getMStore()
+	assert.Nil(t, md.flushFamilyTo(tw, 1))
 }
 
 func Test_ResetMetricStore(t *testing.T) {

--- a/tsdb/memdb/field_store_test.go
+++ b/tsdb/memdb/field_store_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Test_getSegmentStore(t *testing.T) {
-	fStore := newFieldStore("sum", field.SumField)
+	fStore := newFieldStore(field.SumField)
 	sStore, _ := fStore.getSegmentStore(11)
 	assert.Nil(t, sStore)
 	assert.Equal(t, field.SumField, fStore.getFieldType())
@@ -20,10 +20,10 @@ func Test_mustGetFieldID(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	fStore := newFieldStore("sum", field.SumField)
+	fStore := newFieldStore(field.SumField)
 	mockGen := makeMockIDGenerator(ctrl)
-	assert.NotZero(t, fStore.mustGetFieldID(22, mockGen))
-	assert.NotZero(t, fStore.mustGetFieldID(22, mockGen))
+	assert.NotZero(t, fStore.mustGetFieldID(mockGen, 22, "sum"))
+	assert.NotZero(t, fStore.mustGetFieldID(mockGen, 22, "sum"))
 }
 
 func Test_flushFieldTo_write(t *testing.T) {
@@ -34,20 +34,20 @@ func Test_flushFieldTo_write(t *testing.T) {
 	gen := makeMockIDGenerator(ctrl)
 	p := makeMockPoint(ctrl)
 
-	fStore := newFieldStore("sum", field.SumField)
+	fStore := newFieldStore(field.SumField)
 	assert.Equal(t, fStore.getFamiliesCount(), 0)
 	fStore.segments[2] = newSimpleFieldStore(field.GetAggFunc(field.Sum))
 
 	// not exist in fs.segments
-	fStore.flushFieldTo(tw, 32, 1, gen)
+	fStore.flushFieldTo(tw, 32, gen, 1, "sum")
 	// exist in fs.segments
 	assert.Equal(t, fStore.getFamiliesCount(), 1)
 	assert.Equal(t, fStore.getFamiliesCount(), 1)
-	fStore.flushFieldTo(tw, 32, 2, gen)
+	fStore.flushFieldTo(tw, 2, gen, 32, "sum")
 	assert.Equal(t, fStore.getFamiliesCount(), 0)
 
 	for _, f := range p.Fields() {
 		fStore.write(newBlockStore(10), 5, 3, f)
-		fStore.flushFieldTo(tw, 32, 2, gen)
+		fStore.flushFieldTo(tw, 32, gen, 2, "sum")
 	}
 }

--- a/tsdb/memdb/helper_test.go
+++ b/tsdb/memdb/helper_test.go
@@ -23,7 +23,7 @@ import (
 
 func makeMockIDGenerator(ctrl *gomock.Controller) *index.MockIDGenerator {
 	mockGen := index.NewMockIDGenerator(ctrl)
-	mockGen.EXPECT().GenTSID(gomock.Any(), gomock.Any()).
+	mockGen.EXPECT().GenTSID(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(uint32(2222)).AnyTimes()
 	mockGen.EXPECT().GenFieldID(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(uint32(1111)).AnyTimes()
@@ -41,7 +41,7 @@ func makeMockTableWriter(ctrl *gomock.Controller) *metrictbl.MockTableWriter {
 		Return().AnyTimes()
 	mockTW.EXPECT().WriteMetricBlock(gomock.Any()).
 		Return(nil).AnyTimes()
-	mockTW.EXPECT().Close().Return(nil).AnyTimes()
+	mockTW.EXPECT().Commit().Return(nil).AnyTimes()
 
 	return mockTW
 }

--- a/tsdb/memdb/pool_test.go
+++ b/tsdb/memdb/pool_test.go
@@ -17,4 +17,11 @@ func Test_pool(t *testing.T) {
 	metricStoresListPool.get(15)
 	metricStoresListPool.get(1)
 
+	item5 := stringListPool.get(10)
+	stringListPool.put(item5)
+	item6 := stringListPool.get(5)
+	stringListPool.put(item6)
+	stringListPool.get(15)
+	stringListPool.get(1)
+
 }

--- a/tsdb/memdb/segment_store.go
+++ b/tsdb/memdb/segment_store.go
@@ -3,7 +3,6 @@ package memdb
 import (
 	"fmt"
 
-	"github.com/eleme/lindb/pkg/encoding"
 	"github.com/eleme/lindb/pkg/field"
 	"github.com/eleme/lindb/pkg/logger"
 )
@@ -44,7 +43,7 @@ func (fs *simpleFieldStore) writeInt(blockStore *blockStore, slotTime int, value
 		startTime := currentBlock.getStartTime()
 		if slotTime < startTime || slotTime >= startTime+blockStore.timeWindow {
 			// if current slot time out of current time window, need compress block data
-			err := currentBlock.compact(fs.aggFunc)
+			_, _, err := currentBlock.compact(fs.aggFunc)
 			if err != nil {
 				memDBLogger.Error("compress block data error, data will lost", logger.Error(err))
 			} else {
@@ -70,11 +69,10 @@ func (fs *simpleFieldStore) bytes() (data []byte, startSlot, endSlot int, err er
 		err = fmt.Errorf("block is empty")
 		return
 	}
-	if err = fs.block.compact(fs.aggFunc); err != nil {
+	if startSlot, endSlot, err = fs.block.compact(fs.aggFunc); err != nil {
 		err = fmt.Errorf("compact block data in simple field store error:%s", err)
 		return
 	}
 	data = fs.block.bytes()
-	startSlot, endSlot = encoding.DecodeTSDTime(data)
 	return
 }

--- a/tsdb/memdb/timeseries_store.go
+++ b/tsdb/memdb/timeseries_store.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/eleme/lindb/models"
 	"github.com/eleme/lindb/pkg/field"
-	"github.com/eleme/lindb/pkg/hashers"
 	"github.com/eleme/lindb/pkg/lockers"
 	"github.com/eleme/lindb/tsdb/index"
 	"github.com/eleme/lindb/tsdb/metrictbl"
@@ -15,39 +14,35 @@ import (
 // timeSeriesStore holds a mapping relation of field and fieldStore.
 type timeSeriesStore struct {
 	tsID           uint32                 // tsId identifier
-	fields         map[uint32]*fieldStore // key: Fnv32a(fieldName)
+	fields         map[string]*fieldStore // key: fieldName
 	lastAccessedAt int64                  // nanoseconds
 	sl             lockers.SpinLock       // spin-lock
-	tags           *string                // tags identifier, nil after tsID is generated
 }
 
-// newTimeSeriesStore returns a new timeSeriesStore from tags.
-func newTimeSeriesStore(tags string) *timeSeriesStore {
+// newTimeSeriesStore returns a new timeSeriesStore.
+func newTimeSeriesStore() *timeSeriesStore {
 	return &timeSeriesStore{
-		tags:           &tags,
 		lastAccessedAt: time.Now().UnixNano(),
-		fields:         make(map[uint32]*fieldStore)}
+		fields:         make(map[string]*fieldStore)}
 }
 
 // mustGetTSID returns tsID, if unset, generate a new one.
-func (ts *timeSeriesStore) mustGetTSID(metricID uint32, generator index.IDGenerator) uint32 {
+func (ts *timeSeriesStore) mustGetTSID(generator index.IDGenerator, metricID uint32,
+	tags string, version int64) uint32 {
+
 	tsID := atomic.LoadUint32(&ts.tsID)
 	if tsID > 0 {
 		return tsID
 	}
-	theTags := ts.tags
-	if theTags != nil {
-		atomic.CompareAndSwapUint32(&ts.tsID, 0, generator.GenTSID(metricID, *theTags))
-		ts.tags = nil
-	}
+	atomic.CompareAndSwapUint32(&ts.tsID, 0, generator.GenTSID(metricID, tags, version))
 	return atomic.LoadUint32(&ts.tsID)
 }
 
 // generateFieldsID generates fieldID.
 func (ts *timeSeriesStore) generateFieldsID(metricID uint32, generator index.IDGenerator) {
 	ts.sl.Lock()
-	for _, fStore := range ts.fields {
-		fStore.mustGetFieldID(metricID, generator)
+	for fieldName, fStore := range ts.fields {
+		fStore.mustGetFieldID(generator, metricID, fieldName)
 	}
 	ts.sl.Unlock()
 }
@@ -55,18 +50,17 @@ func (ts *timeSeriesStore) generateFieldsID(metricID uint32, generator index.IDG
 // getOrCreateFStore mustGet a fieldStore by fieldName.
 func (ts *timeSeriesStore) getOrCreateFStore(fieldName string, fieldType field.Type) (*fieldStore, error) {
 	atomic.StoreInt64(&ts.lastAccessedAt, time.Now().UnixNano())
-	fieldHash := hashers.Fnv32a(fieldName)
 
 	ts.sl.Lock()
-	store, exist := ts.fields[fieldHash]
+	store, exist := ts.fields[fieldName]
 	if exist {
 		if store.getFieldType() != fieldType {
 			ts.sl.Unlock()
 			return nil, models.ErrWrongFieldType
 		}
 	} else {
-		store = newFieldStore(fieldName, fieldType)
-		ts.fields[fieldHash] = store
+		store = newFieldStore(fieldType)
+		ts.fields[fieldName] = store
 	}
 	ts.sl.Unlock()
 	return store, nil
@@ -105,13 +99,13 @@ func (ts *timeSeriesStore) getFieldsCount() int {
 }
 
 // flushTSEntryTo flushes the tsEntry data segment.
-func (ts *timeSeriesStore) flushTSEntryTo(writer metrictbl.TableWriter, metricID uint32,
-	familyTime int64, generator index.IDGenerator) {
-	tsID := ts.mustGetTSID(metricID, generator)
+func (ts *timeSeriesStore) flushTSEntryTo(writer metrictbl.TableWriter, familyTime int64,
+	generator index.IDGenerator, metricID uint32, tags string, version int64) {
 
+	tsID := ts.mustGetTSID(generator, metricID, tags, version)
 	ts.sl.Lock()
-	for _, fStore := range ts.fields {
-		fStore.flushFieldTo(writer, metricID, familyTime, generator)
+	for fieldName, fStore := range ts.fields {
+		fStore.flushFieldTo(writer, familyTime, generator, metricID, fieldName)
 	}
 	writer.WriteTSEntry(tsID)
 	ts.sl.Unlock()

--- a/tsdb/metrictbl/reader.go
+++ b/tsdb/metrictbl/reader.go
@@ -1,0 +1,9 @@
+package metrictbl
+
+//go:generate mockgen -source ./reader.go -destination=./reader_mock.go -package metrictbl
+
+// TableReader reads metrics from sstable.
+type TableReader interface {
+	ContainsMetric(metricID uint32, startTime, endTime int) bool
+	ContainsTSEntry(uint32) bool
+}

--- a/tsdb/metrictbl/reader_test.go
+++ b/tsdb/metrictbl/reader_test.go
@@ -1,0 +1,1 @@
+package metrictbl

--- a/vendor/github.com/golang/mock/gomock/call.go
+++ b/vendor/github.com/golang/mock/gomock/call.go
@@ -23,7 +23,7 @@ import (
 
 // Call represents an expected call to a mock.
 type Call struct {
-	t TestReporter // for triggering test failures on invalid call setup
+	t TestHelper // for triggering test failures on invalid call setup
 
 	receiver   interface{}  // the receiver of the method call
 	method     string       // the name of the method
@@ -46,10 +46,8 @@ type Call struct {
 
 // newCall creates a *Call. It requires the method type in order to support
 // unexported methods.
-func newCall(t TestReporter, receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
-	if h, ok := t.(testHelper); ok {
-		h.Helper()
-	}
+func newCall(t TestHelper, receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
+	t.Helper()
 
 	// TODO: check arity, types.
 	margs := make([]Matcher, len(args))
@@ -159,9 +157,7 @@ func (c *Call) Do(f interface{}) *Call {
 
 // Return declares the values to be returned by the mocked function call.
 func (c *Call) Return(rets ...interface{}) *Call {
-	if h, ok := c.t.(testHelper); ok {
-		h.Helper()
-	}
+	c.t.Helper()
 
 	mt := c.methodType
 	if len(rets) != mt.NumOut() {
@@ -209,9 +205,7 @@ func (c *Call) Times(n int) *Call {
 // indirected through a pointer. Or, in the case of a slice, SetArg
 // will copy value's elements into the nth argument.
 func (c *Call) SetArg(n int, value interface{}) *Call {
-	if h, ok := c.t.(testHelper); ok {
-		h.Helper()
-	}
+	c.t.Helper()
 
 	mt := c.methodType
 	// TODO: This will break on variadic methods.
@@ -264,9 +258,7 @@ func (c *Call) isPreReq(other *Call) bool {
 
 // After declares that the call may only match after preReq has been exhausted.
 func (c *Call) After(preReq *Call) *Call {
-	if h, ok := c.t.(testHelper); ok {
-		h.Helper()
-	}
+	c.t.Helper()
 
 	if c == preReq {
 		c.t.Fatalf("A call isn't allowed to be its own prerequisite")

--- a/vendor/github.com/golang/mock/gomock/controller.go
+++ b/vendor/github.com/golang/mock/gomock/controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// GoMock - a mock framework for Go.
+// Package gomock is a mock framework for Go.
 //
 // Standard usage:
 //   (1) Define an interface that you wish to mock.
@@ -56,59 +56,111 @@
 package gomock
 
 import (
+	"context"
 	"fmt"
-	"golang.org/x/net/context"
 	"reflect"
 	"runtime"
 	"sync"
 )
 
-// A TestReporter is something that can be used to report test failures.
-// It is satisfied by the standard library's *testing.T.
+// A TestReporter is something that can be used to report test failures.  It
+// is satisfied by the standard library's *testing.T.
 type TestReporter interface {
 	Errorf(format string, args ...interface{})
 	Fatalf(format string, args ...interface{})
 }
 
-// A Controller represents the top-level control of a mock ecosystem.
-// It defines the scope and lifetime of mock objects, as well as their expectations.
-// It is safe to call Controller's methods from multiple goroutines.
+// TestHelper is a TestReporter that has the Helper method.  It is satisfied
+// by the standard library's *testing.T.
+type TestHelper interface {
+	TestReporter
+	Helper()
+}
+
+// A Controller represents the top-level control of a mock ecosystem.  It
+// defines the scope and lifetime of mock objects, as well as their
+// expectations.  It is safe to call Controller's methods from multiple
+// goroutines. Each test should create a new Controller and invoke Finish via
+// defer.
+//
+//   func TestFoo(t *testing.T) {
+//     ctrl := gomock.NewController(st)
+//     defer ctrl.Finish()
+//     // ..
+//   }
+//
+//   func TestBar(t *testing.T) {
+//     t.Run("Sub-Test-1", st) {
+//       ctrl := gomock.NewController(st)
+//       defer ctrl.Finish()
+//       // ..
+//     })
+//     t.Run("Sub-Test-2", st) {
+//       ctrl := gomock.NewController(st)
+//       defer ctrl.Finish()
+//       // ..
+//     })
+//   })
 type Controller struct {
+	// T should only be called within a generated mock. It is not intended to
+	// be used in user code and may be changed in future versions. T is the
+	// TestReporter passed in when creating the Controller via NewController.
+	// If the TestReporter does not implement a TestHelper it will be wrapped
+	// with a nopTestHelper.
+	T             TestHelper
 	mu            sync.Mutex
-	t             TestReporter
 	expectedCalls *callSet
 	finished      bool
 }
 
+// NewController returns a new Controller. It is the preferred way to create a
+// Controller.
 func NewController(t TestReporter) *Controller {
+	h, ok := t.(TestHelper)
+	if !ok {
+		h = nopTestHelper{t}
+	}
+
 	return &Controller{
-		t:             t,
+		T:             h,
 		expectedCalls: newCallSet(),
 	}
 }
 
 type cancelReporter struct {
-	t      TestReporter
+	TestHelper
 	cancel func()
 }
 
-func (r *cancelReporter) Errorf(format string, args ...interface{}) { r.t.Errorf(format, args...) }
+func (r *cancelReporter) Errorf(format string, args ...interface{}) {
+	r.TestHelper.Errorf(format, args...)
+}
 func (r *cancelReporter) Fatalf(format string, args ...interface{}) {
 	defer r.cancel()
-	r.t.Fatalf(format, args...)
+	r.TestHelper.Fatalf(format, args...)
 }
 
 // WithContext returns a new Controller and a Context, which is cancelled on any
 // fatal failure.
 func WithContext(ctx context.Context, t TestReporter) (*Controller, context.Context) {
+	h, ok := t.(TestHelper)
+	if !ok {
+		h = nopTestHelper{t}
+	}
+
 	ctx, cancel := context.WithCancel(ctx)
-	return NewController(&cancelReporter{t, cancel}), ctx
+	return NewController(&cancelReporter{h, cancel}), ctx
 }
 
+type nopTestHelper struct {
+	TestReporter
+}
+
+func (h nopTestHelper) Helper() {}
+
+// RecordCall is called by a mock. It should not be called by user code.
 func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...interface{}) *Call {
-	if h, ok := ctrl.t.(testHelper); ok {
-		h.Helper()
-	}
+	ctrl.T.Helper()
 
 	recv := reflect.ValueOf(receiver)
 	for i := 0; i < recv.Type().NumMethod(); i++ {
@@ -116,16 +168,15 @@ func (ctrl *Controller) RecordCall(receiver interface{}, method string, args ...
 			return ctrl.RecordCallWithMethodType(receiver, method, recv.Method(i).Type(), args...)
 		}
 	}
-	ctrl.t.Fatalf("gomock: failed finding method %s on %T", method, receiver)
+	ctrl.T.Fatalf("gomock: failed finding method %s on %T", method, receiver)
 	panic("unreachable")
 }
 
+// RecordCallWithMethodType is called by a mock. It should not be called by user code.
 func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method string, methodType reflect.Type, args ...interface{}) *Call {
-	if h, ok := ctrl.t.(testHelper); ok {
-		h.Helper()
-	}
+	ctrl.T.Helper()
 
-	call := newCall(ctrl.t, receiver, method, methodType, args...)
+	call := newCall(ctrl.T, receiver, method, methodType, args...)
 
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
@@ -134,20 +185,20 @@ func (ctrl *Controller) RecordCallWithMethodType(receiver interface{}, method st
 	return call
 }
 
+// Call is called by a mock. It should not be called by user code.
 func (ctrl *Controller) Call(receiver interface{}, method string, args ...interface{}) []interface{} {
-	if h, ok := ctrl.t.(testHelper); ok {
-		h.Helper()
-	}
+	ctrl.T.Helper()
 
 	// Nest this code so we can use defer to make sure the lock is released.
 	actions := func() []func([]interface{}) []interface{} {
+		ctrl.T.Helper()
 		ctrl.mu.Lock()
 		defer ctrl.mu.Unlock()
 
 		expected, err := ctrl.expectedCalls.FindMatch(receiver, method, args)
 		if err != nil {
 			origin := callerInfo(2)
-			ctrl.t.Fatalf("Unexpected call to %T.%v(%v) at %s because: %s", receiver, method, args, origin, err)
+			ctrl.T.Fatalf("Unexpected call to %T.%v(%v) at %s because: %s", receiver, method, args, origin, err)
 		}
 
 		// Two things happen here:
@@ -175,16 +226,17 @@ func (ctrl *Controller) Call(receiver interface{}, method string, args ...interf
 	return rets
 }
 
+// Finish checks to see if all the methods that were expected to be called
+// were called. It should be invoked for each Controller. It is not idempotent
+// and therefore can only be invoked once.
 func (ctrl *Controller) Finish() {
-	if h, ok := ctrl.t.(testHelper); ok {
-		h.Helper()
-	}
+	ctrl.T.Helper()
 
 	ctrl.mu.Lock()
 	defer ctrl.mu.Unlock()
 
 	if ctrl.finished {
-		ctrl.t.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
+		ctrl.T.Fatalf("Controller.Finish was called more than once. It has to be called exactly once.")
 	}
 	ctrl.finished = true
 
@@ -197,10 +249,10 @@ func (ctrl *Controller) Finish() {
 	// Check that all remaining expected calls are satisfied.
 	failures := ctrl.expectedCalls.Failures()
 	for _, call := range failures {
-		ctrl.t.Errorf("missing call(s) to %v", call)
+		ctrl.T.Errorf("missing call(s) to %v", call)
 	}
 	if len(failures) != 0 {
-		ctrl.t.Fatalf("aborting test due to missing call(s)")
+		ctrl.T.Fatalf("aborting test due to missing call(s)")
 	}
 }
 
@@ -209,9 +261,4 @@ func callerInfo(skip int) string {
 		return fmt.Sprintf("%s:%d", file, line)
 	}
 	return "unknown file"
-}
-
-type testHelper interface {
-	TestReporter
-	Helper()
 }

--- a/vendor/github.com/golang/mock/gomock/matchers.go
+++ b/vendor/github.com/golang/mock/gomock/matchers.go
@@ -1,5 +1,3 @@
-//go:generate mockgen -destination mock_matcher/mock_matcher.go github.com/golang/mock/gomock Matcher
-
 // Copyright 2010 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,13 +85,57 @@ func (n notMatcher) String() string {
 	return "not(" + n.m.String() + ")"
 }
 
+type assignableToTypeOfMatcher struct {
+	targetType reflect.Type
+}
+
+func (m assignableToTypeOfMatcher) Matches(x interface{}) bool {
+	return reflect.TypeOf(x).AssignableTo(m.targetType)
+}
+
+func (m assignableToTypeOfMatcher) String() string {
+	return "is assignable to " + m.targetType.Name()
+}
+
 // Constructors
-func Any() Matcher             { return anyMatcher{} }
+// Any returns a matcher that always matches.
+func Any() Matcher { return anyMatcher{} }
+
+// Eq returns a matcher that matches on equality.
+//
+// Example usage:
+//   Eq(5).Matches(5) // returns true
+//   Eq(5).Matches(4) // returns false
 func Eq(x interface{}) Matcher { return eqMatcher{x} }
-func Nil() Matcher             { return nilMatcher{} }
+
+// Nil returns a matcher that matches if the received value is nil.
+//
+// Example usage:
+//   var x *bytes.Buffer
+//   Nil().Matches(x) // returns true
+//   x = &bytes.Buffer{}
+//   Nil().Matches(x) // returns false
+func Nil() Matcher { return nilMatcher{} }
+
+// Not reverses the results of its given child matcher.
+//
+// Example usage:
+//   Not(Eq(5)).Matches(4) // returns true
+//   Not(Eq(5)).Matches(5) // returns false
 func Not(x interface{}) Matcher {
 	if m, ok := x.(Matcher); ok {
 		return notMatcher{m}
 	}
 	return notMatcher{Eq(x)}
+}
+
+// AssignableToTypeOf is a Matcher that matches if the parameter to the mock
+// function is assignable to the type of the parameter to this function.
+//
+// Example usage:
+//   var s fmt.Stringer = &bytes.Buffer{}
+//   AssignableToTypeOf(s).Matches(time.Second) // returns true
+//   AssignableToTypeOf(s).Matches(99) // returns false
+func AssignableToTypeOf(x interface{}) Matcher {
+	return assignableToTypeOfMatcher{reflect.TypeOf(x)}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/protoc-gen-gogo/descriptor
 # github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef
 github.com/golang/groupcache/lru
-# github.com/golang/mock v1.1.1
+# github.com/golang/mock v1.3.1
 github.com/golang/mock/gomock
 # github.com/golang/protobuf v1.3.1
 github.com/golang/protobuf/proto
@@ -220,10 +220,10 @@ golang.org/x/crypto/ssh/terminal
 golang.org/x/crypto/blowfish
 # golang.org/x/net v0.0.0-20190628185345-da137c7871d7
 golang.org/x/net/trace
-golang.org/x/net/context
 golang.org/x/net/internal/timeseries
 golang.org/x/net/http2
 golang.org/x/net/http2/hpack
+golang.org/x/net/context
 golang.org/x/net/http/httpguts
 golang.org/x/net/idna
 # golang.org/x/sys v0.0.0-20190730174312-6a60838ec25


### PR DESCRIPTION
- update gomock version
- fix mock
- remove hash-number-key in memdb