### PR TITLE
[feat:#108][coordinator:replica]: replica state of database for broke query

### DIFF
--- a/constants/coordinator.go
+++ b/constants/coordinator.go
@@ -18,10 +18,12 @@ const (
 const (
 	// StorageClusterConfigPath represents cluster config store
 	StorageClusterConfigPath = "/storage/cluster/config"
-	// StorageClusterStatePath represents storage cluster state
-	StorageClusterStatePath = "/storage/cluster/state"
 	// DatabaseConfigPath represents database config path
 	DatabaseConfigPath = "/database/config"
+	// StorageClusterStatePath represents storage cluster state
+	StorageClusterStatePath = "/state/storage/cluster"
+	// ReplicaStatePath represents the replica's state
+	ReplicaStatePath = "/state/replica"
 )
 
 // defines all task kinds

--- a/coordinator/discovery/registry.go
+++ b/coordinator/discovery/registry.go
@@ -54,7 +54,7 @@ func (r *registry) Register(node models.Node) error {
 		return err
 	}
 	// register node info
-	path := pathutil.GetNodePath(r.prefix, node.String())
+	path := pathutil.GetNodePath(r.prefix, node.Indicator())
 	// register node if fail retry it
 	go r.register(path, nodeBytes)
 	return nil
@@ -62,7 +62,7 @@ func (r *registry) Register(node models.Node) error {
 
 // Deregister deregisters node info, remove it from active list
 func (r *registry) Deregister(node models.Node) error {
-	return r.repo.Delete(r.ctx, pathutil.GetNodePath(r.prefix, node.String()))
+	return r.repo.Delete(r.ctx, pathutil.GetNodePath(r.prefix, node.Indicator()))
 }
 
 // Close closes registry, releases resources

--- a/coordinator/discovery/registry_test.go
+++ b/coordinator/discovery/registry_test.go
@@ -40,7 +40,7 @@ func (ts *testRegistrySuite) TestRegister(c *check.C) {
 	// wait register success
 	time.Sleep(500 * time.Millisecond)
 
-	nodePath := fmt.Sprintf("%s/%s", testRegistryPath, node.String())
+	nodePath := fmt.Sprintf("%s/%s", testRegistryPath, node.Indicator())
 	nodeBytes, _ := repo.Get(context.TODO(), nodePath)
 	nodeInfo := models.Node{}
 	_ = json.Unmarshal(nodeBytes, &nodeInfo)
@@ -80,7 +80,7 @@ func (ts *testRegistrySuite) TestDeregister(c *check.C) {
 	// wait register success
 	time.Sleep(500 * time.Millisecond)
 
-	nodePath := fmt.Sprintf("%s/%s", testRegistryPath, node.String())
+	nodePath := fmt.Sprintf("%s/%s", testRegistryPath, node.Indicator())
 	nodeBytes, _ := repo.Get(context.TODO(), nodePath)
 	nodeInfo := models.Node{}
 	_ = json.Unmarshal(nodeBytes, &nodeInfo)

--- a/coordinator/replica/status_state_machine.go
+++ b/coordinator/replica/status_state_machine.go
@@ -1,0 +1,135 @@
+package replica
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/eleme/lindb/constants"
+	"github.com/eleme/lindb/coordinator/discovery"
+	"github.com/eleme/lindb/models"
+	"github.com/eleme/lindb/pkg/logger"
+	"github.com/eleme/lindb/pkg/pathutil"
+	"github.com/eleme/lindb/pkg/state"
+)
+
+//go:generate mockgen -source=./status_state_machine.go -destination=./status_state_machine_mock.go -package=replica
+
+// StatusStateMachine represents the status of database's replicas
+// Each broker node need start this state machine,
+type StatusStateMachine interface {
+	discovery.Listener
+	// GetQueryableReplicas returns the queryable replicas，
+	// and chooses the fastest replica if the shard has multi-replica.
+	// returns storage node => shard id list
+	GetQueryableReplicas(database string) map[string][]int32
+	// GetReplicas returns the replica state list under this broker by broker's indicator
+	GetReplicas(broker string) models.BrokerReplicaState
+}
+
+// statusStateMachine implements status state machine,
+// watches replica state path for listening modify event which broker uploaded
+type statusStateMachine struct {
+	repo      state.Repository
+	discovery discovery.Discovery
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mutex sync.RWMutex
+	// brokers: broker node => replica list under this broker
+	brokers map[string]models.BrokerReplicaState
+
+	log *logger.Logger
+}
+
+// NewStatusStateMachine creates a replica's status state machine
+func NewStatusStateMachine(ctx context.Context, repo state.Repository) (StatusStateMachine, error) {
+	c, cancel := context.WithCancel(ctx)
+	sm := &statusStateMachine{
+		repo:    repo,
+		ctx:     c,
+		cancel:  cancel,
+		brokers: make(map[string]models.BrokerReplicaState),
+		log:     logger.GetLogger("replica/status/state/machine"),
+	}
+	// new replica status discovery
+	sm.discovery = discovery.NewDiscovery(repo, constants.ReplicaStatePath, sm)
+	if err := sm.discovery.Discovery(); err != nil {
+		return nil, fmt.Errorf("discovery database status error:%s", err)
+	}
+	return sm, nil
+}
+
+func (sm *statusStateMachine) Cleanup() {
+	// do nothing
+}
+
+// GetQueryableReplicas returns the queryable replicas
+// returns storage node => shard id list
+func (sm *statusStateMachine) GetQueryableReplicas(database string) map[string][]int32 {
+	// 1. find shards by given database's name
+	shards := make(map[string][]models.ReplicaState)
+	sm.mutex.RLock()
+	for _, brokerReplicaState := range sm.brokers {
+		for _, replica := range brokerReplicaState.Replicas {
+			if replica.Database != database {
+				continue
+			}
+			shardID := replica.ShardIndicator()
+			shards[shardID] = append(shards[shardID], replica)
+		}
+	}
+	sm.mutex.RUnlock()
+
+	if len(shards) == 0 {
+		return nil
+	}
+
+	result := make(map[string][]int32)
+	for _, replicas := range shards {
+		replicaList := replicas
+		if len(replicaList) > 1 {
+			// has multi-replica, chooses the fastest
+			// sort replicas based pending msg
+			sort.Slice(replicaList, func(i, j int) bool {
+				return replicaList[i].Pending() < replicaList[j].Pending()
+			})
+		}
+		nodeID := replicaList[0].TO.Indicator()
+		result[nodeID] = append(result[nodeID], replicaList[0].ShardID)
+	}
+
+	return result
+}
+
+// GetReplicas returns the replica state list under this broker by broker's indicator
+func (sm *statusStateMachine) GetReplicas(broker string) models.BrokerReplicaState {
+	sm.mutex.RLock()
+	defer sm.mutex.RUnlock()
+	return sm.brokers[broker]
+}
+
+// OnCreates updates the broker's replica status when broker upload replica state
+func (sm *statusStateMachine) OnCreate(key string, resource []byte) {
+	brokerReplicaState := models.BrokerReplicaState{}
+	if err := json.Unmarshal(resource, &brokerReplicaState); err != nil {
+		sm.log.Error("discovery replica status but unmarshal error",
+			logger.String("data", string(resource)), logger.Error(err))
+		return
+	}
+	broker := pathutil.GetName(key)
+	sm.mutex.Lock()
+	sm.brokers[broker] = brokerReplicaState
+	sm.mutex.Unlock()
+}
+
+// OnDelete deletes the broker's replica status when broker offline
+func (sm *statusStateMachine) OnDelete(key string) {
+	broker := pathutil.GetName(key)
+	sm.mutex.Lock()
+	delete(sm.brokers, broker)
+	sm.mutex.Unlock()
+}

--- a/coordinator/replica/status_state_machine_test.go
+++ b/coordinator/replica/status_state_machine_test.go
@@ -1,0 +1,172 @@
+package replica
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/eleme/lindb/constants"
+	"github.com/eleme/lindb/models"
+	"github.com/eleme/lindb/pkg/pathutil"
+	"github.com/eleme/lindb/pkg/state"
+)
+
+func TestStatusStateMachine(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eventCh := make(chan *state.Event)
+	repo := state.NewMockRepository(ctrl)
+	repo.EXPECT().WatchPrefix(gomock.Any(), constants.ReplicaStatePath).Return(eventCh)
+
+	sm, err := NewStatusStateMachine(context.TODO(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotNil(t, sm)
+
+	replicaStatus := []models.ReplicaState{{
+		Cluster:  "test",
+		Database: "11",
+	}}
+	data, _ := json.Marshal(models.BrokerReplicaState{Replicas: replicaStatus})
+
+	// wrong event
+	sendEvent(eventCh, &state.Event{
+		Type: state.EventTypeModify,
+		KeyValues: []state.EventKeyValue{
+			{Key: pathutil.GetReplicaStatePath("1.1.1.1:2080"), Value: nil},
+		},
+	})
+	assert.Equal(t, 0, len(sm.GetReplicas("1.1.1.1:2080").Replicas))
+	// modify event
+	sendEvent(eventCh, &state.Event{
+		Type: state.EventTypeModify,
+		KeyValues: []state.EventKeyValue{
+			{Key: pathutil.GetReplicaStatePath("1.1.1.1:2080"), Value: data},
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, replicaStatus, sm.GetReplicas("1.1.1.1:2080").Replicas)
+	assert.Equal(t, 0, len(sm.GetReplicas("1.1.1.2:2080").Replicas))
+	// delete event
+	sendEvent(eventCh, &state.Event{
+		Type: state.EventTypeDelete,
+		KeyValues: []state.EventKeyValue{
+			{Key: pathutil.GetReplicaStatePath("1.1.1.1:2080")},
+		},
+	})
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, 0, len(sm.GetReplicas("1.1.1.1:2080").Replicas))
+}
+
+func TestStatusStateMachine_GetQueryableReplicas(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	eventCh := make(chan *state.Event)
+	repo := state.NewMockRepository(ctrl)
+	repo.EXPECT().WatchPrefix(gomock.Any(), constants.ReplicaStatePath).Return(eventCh)
+
+	sm, err := NewStatusStateMachine(context.TODO(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 0, len(sm.GetQueryableReplicas("test")))
+
+	// broker 1:
+	replicaStatus := []models.ReplicaState{
+		{
+			Cluster:      "test",
+			Database:     "test_db_2",
+			TO:           models.Node{IP: "1.1.1.2", Port: 2090},
+			WriteIndex:   100,
+			ReplicaIndex: 50,
+			ShardID:      1,
+		},
+		{
+			Cluster:      "test",
+			Database:     "test_db",
+			TO:           models.Node{IP: "1.1.1.2", Port: 2090},
+			WriteIndex:   100,
+			ReplicaIndex: 50,
+			ShardID:      1,
+		},
+		{
+			Cluster:      "test",
+			Database:     "test_db",
+			TO:           models.Node{IP: "1.1.1.3", Port: 2090},
+			WriteIndex:   100,
+			ReplicaIndex: 90,
+			ShardID:      1,
+		},
+	}
+	data, _ := json.Marshal(models.BrokerReplicaState{Replicas: replicaStatus})
+	sendEvent(eventCh, &state.Event{
+		Type: state.EventTypeModify,
+		KeyValues: []state.EventKeyValue{
+			{Key: pathutil.GetReplicaStatePath("2.1.1.1:2080"), Value: data},
+		},
+	})
+
+	// broker 2:
+	replicaStatus = []models.ReplicaState{
+		{
+			Cluster:      "test",
+			Database:     "test_db_2",
+			TO:           models.Node{IP: "1.1.1.2", Port: 2090},
+			WriteIndex:   100,
+			ReplicaIndex: 50,
+			ShardID:      2,
+		},
+		{
+			Cluster:      "test",
+			Database:     "test_db",
+			TO:           models.Node{IP: "1.1.1.2", Port: 2090},
+			WriteIndex:   100,
+			ReplicaIndex: 50,
+			ShardID:      2,
+		},
+		{
+			Cluster:      "test",
+			Database:     "test_db",
+			TO:           models.Node{IP: "1.1.1.3", Port: 2090},
+			WriteIndex:   100,
+			ReplicaIndex: 90,
+			ShardID:      2,
+		},
+	}
+	data, _ = json.Marshal(models.BrokerReplicaState{Replicas: replicaStatus})
+	sendEvent(eventCh, &state.Event{
+		Type: state.EventTypeModify,
+		KeyValues: []state.EventKeyValue{
+			{Key: pathutil.GetReplicaStatePath("2.1.1.2:2080"), Value: data},
+		},
+	})
+
+	r := sm.GetQueryableReplicas("test_db")
+	assert.Equal(t, 1, len(r))
+	shards := r["1.1.1.3:2090"]
+	sort.Slice(shards, func(i, j int) bool {
+		return shards[i] < shards[j]
+	})
+	assert.Equal(t, []int32{1, 2}, shards)
+
+	r = sm.GetQueryableReplicas("test_db_2")
+	assert.Equal(t, 1, len(r))
+	shards = r["1.1.1.2:2090"]
+	sort.Slice(shards, func(i, j int) bool {
+		return shards[i] < shards[j]
+	})
+	assert.Equal(t, []int32{1, 2}, shards)
+}
+
+func sendEvent(eventCh chan *state.Event, event *state.Event) {
+	eventCh <- event
+	time.Sleep(10 * time.Millisecond)
+}

--- a/coordinator/storage/cluster.go
+++ b/coordinator/storage/cluster.go
@@ -158,7 +158,7 @@ func (c *cluster) SaveShardAssign(databaseName string, shardAssign *models.Shard
 	for nodeID, taskParam := range tasks {
 		node := shardAssign.Nodes[nodeID]
 		params = append(params, task.ControllerTaskParam{
-			NodeID: node.String(),
+			NodeID: node.Indicator(),
 			Params: taskParam,
 		})
 	}

--- a/coordinator/task/executor.go
+++ b/coordinator/task/executor.go
@@ -26,7 +26,7 @@ type Executor struct {
 func NewExecutor(ctx context.Context, node *models.Node, cli state.Repository) *Executor {
 	ctx, cancel := context.WithCancel(ctx)
 	return &Executor{
-		keypfx:     fmt.Sprintf("/task-coordinator/%s/executor/%s/", version, node.String()),
+		keypfx:     fmt.Sprintf("/task-coordinator/%s/executor/%s/", version, node.Indicator()),
 		cli:        cli,
 		node:       node,
 		processors: map[Kind]*taskProcessor{},

--- a/coordinator/task/task_test.go
+++ b/coordinator/task/task_test.go
@@ -54,8 +54,8 @@ func (ts *testTaskSuite) Test_tasks(c *check.C) {
 		_ = controller.Close()
 	}()
 	err := controller.Submit(kindDummy, "wtf-2019-07-05--1", []ControllerTaskParam{
-		{NodeID: node1.String(), Params: dummyParams{}},
-		{NodeID: node2.String(), Params: dummyParams{}},
+		{NodeID: node1.Indicator(), Params: dummyParams{}},
+		{NodeID: node2.Indicator(), Params: dummyParams{}},
 	})
 	if err != nil {
 		c.Fatal(err)

--- a/models/node.go
+++ b/models/node.go
@@ -10,8 +10,8 @@ type Node struct {
 	Port uint16 `json:"port"`
 }
 
-// String returns node info string
-func (n *Node) String() string {
+// Indicator returns return node indicator's string
+func (n *Node) Indicator() string {
 	return fmt.Sprintf("%s:%d", n.IP, n.Port)
 }
 

--- a/models/relicator.go
+++ b/models/relicator.go
@@ -1,0 +1,30 @@
+package models
+
+import "fmt"
+
+// BrokerReplicaState represents the replica state list of the broker
+type BrokerReplicaState struct {
+	ReportTime int64          `json:"reportTime"` // broker report state's time(millisecond)
+	Replicas   []ReplicaState `json:"replicas"`   // replica state list under this broker
+}
+
+// ReplicaState represents the status of replicator's channel
+type ReplicaState struct {
+	Cluster      string `json:"cluster"`      // cluster which storing database
+	Database     string `json:"database"`     // database name
+	ShardID      int32  `json:"shardID"`      // shard id
+	TO           Node   `json:"to"`           // target storage node for database's shard
+	WriteIndex   int64  `json:"writeIndex"`   // wal write index
+	ReplicaIndex int64  `json:"replicaIndex"` // replica index for current replicator's channel
+	CommitIndex  int64  `json:"commitIndex"`  // commit index
+}
+
+// ShardIndicator returns shard indicator based on cluster/database/shard id
+func (r ReplicaState) ShardIndicator() string {
+	return fmt.Sprintf("%s/%s/%d", r.Cluster, r.Database, r.ShardID)
+}
+
+// Pending returns the num. of pending which it need replica msg
+func (r ReplicaState) Pending() int64 {
+	return r.WriteIndex - r.ReplicaIndex
+}

--- a/models/state.go
+++ b/models/state.go
@@ -16,7 +16,7 @@ func NewStorageState() *StorageState {
 
 // AddActiveNode adds a node into active node list
 func (s *StorageState) AddActiveNode(node *Node) {
-	key := node.String()
+	key := node.Indicator()
 	_, ok := s.ActiveNodes[key]
 	if !ok {
 		s.ActiveNodes[key] = node

--- a/models/user.go
+++ b/models/user.go
@@ -1,11 +1,7 @@
 package models
 
-// User user system model
+// User represents user model
 type User struct {
 	UserName string `toml:"username" json:"UserName"`
 	Password string `toml:"password" json:"Password"`
-}
-
-type JwtToken struct {
-	Token string
 }

--- a/pkg/pathutil/coordinator.go
+++ b/pkg/pathutil/coordinator.go
@@ -32,6 +32,11 @@ func GetNodePath(prefix, node string) string {
 	return fmt.Sprintf("%s/%s", prefix, node)
 }
 
+// GetReplicaStatePath returns replica's state path
+func GetReplicaStatePath(node string) string {
+	return fmt.Sprintf("%s/%s", constants.ReplicaStatePath, node)
+}
+
 // GetName returns name, splits path and gets last path
 func GetName(path string) string {
 	_, name := filepath.Split(path)

--- a/pkg/pathutil/coordinator_test.go
+++ b/pkg/pathutil/coordinator_test.go
@@ -31,3 +31,7 @@ func TestGetStorageClusterConfigPath(t *testing.T) {
 func TestGetStorageClusterStatePath(t *testing.T) {
 	assert.Equal(t, constants.StorageClusterStatePath+"/name", GetStorageClusterStatePath("name"))
 }
+
+func TestGetReplicaStatePath(t *testing.T) {
+	assert.Equal(t, constants.ReplicaStatePath+"/1.1.1.1:port", GetReplicaStatePath("1.1.1.1:port"))
+}

--- a/pkg/state/repository.go
+++ b/pkg/state/repository.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 )
 
+//go:generate mockgen -source=./repository.go -destination=./repository_mock.go -package=state
+
 var (
 	// ErrNotExist represents key not exist
 	ErrNotExist = errors.New("not exist")

--- a/sql/stmt/expr.go
+++ b/sql/stmt/expr.go
@@ -10,6 +10,7 @@ type Expr interface {
 
 // TagFilter represents tag filter for searching time series
 type TagFilter interface {
+	// TagKey returns the filter's tag key
 	TagKey() string
 }
 
@@ -81,7 +82,14 @@ func (e *InExpr) expr()     {}
 func (e *LikeExpr) expr()   {}
 func (e *RegexExpr) expr()  {}
 
+// TagKey returns the equals filter's tag key
 func (e *EqualsExpr) TagKey() string { return e.Key }
-func (e *InExpr) TagKey() string     { return e.Key }
-func (e *LikeExpr) TagKey() string   { return e.Key }
-func (e *RegexExpr) TagKey() string  { return e.Key }
+
+// TagKey returns the in filter's tag key
+func (e *InExpr) TagKey() string { return e.Key }
+
+// TagKey returns the like filter's tag key
+func (e *LikeExpr) TagKey() string { return e.Key }
+
+// TagKey returns the regex filter's tag key
+func (e *RegexExpr) TagKey() string { return e.Key }

--- a/storage/runtime_test.go
+++ b/storage/runtime_test.go
@@ -63,7 +63,7 @@ func (ts *testStorageRuntimeSuite) TestStorageRun(c *check.C) {
 	time.Sleep(200 * time.Millisecond)
 
 	runtime, _ := storage.(*runtime)
-	nodePath := pathutil.GetNodePath(constants.ActiveNodesPath, runtime.node.String())
+	nodePath := pathutil.GetNodePath(constants.ActiveNodesPath, runtime.node.Indicator())
 	nodeBytes, err := runtime.repo.Get(context.TODO(), nodePath)
 	if err != nil {
 		c.Fatal(err)


### PR DESCRIPTION
1. discovery replica state of each broker
2. choose queryable storage node and shard ids for database